### PR TITLE
Add Numerous New Options

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,7 @@ This will plot dewpoint on the station plot for 850 and 925 (700 mb will always 
 ## Output
 
 By default, this script will output upper air maps as PNG files. Using the option `--compress_output` will enable more aggressive PNG optimization, including compression and indexing, reducing the file size by approximately 60%. This comes at the cost of an increased run time.
+
+## Additional Options
+
+* The flag `--cwd` will tell the application to use the current working directory rather than a hard-coded path.

--- a/README.md
+++ b/README.md
@@ -54,13 +54,13 @@ This will plot dewpoint on the station plot for 850 and 925 (700 mb will always 
 
 ## Output
 
-By default, this script will output upper air maps as PNG files. Using the option `--compress_output` will enable more aggressive PNG optimization, including compression and indexing, reducing the file size by approximately 60%. This comes at the cost of an increased run time.
+By default, this script will output upper air maps as PNG files. Using the option `--compress-output` will enable more aggressive PNG optimization, including compression and indexing, reducing the file size by approximately 60%. This comes at the cost of an increased run time.
 
-The flag `--png_colours` can be used to specify the number of colours used in the output image. For example, `--png_colours 32` to restrict the output file to 32 colours. The default is 256 colours.
+The flag `--png-colours` can be used to specify the number of colours used in the output image. For example, `--png-colours 32` to restrict the output file to 32 colours. The default is 256 colours.
 
-If you want the script to also generate thumbnail images, add the `--thumbnails` flag. You can specify the maximum pixel dimension of the generated thumbnail using `--thumbnail_size` with an integer value. The default is 640 pixels.
+If you want the script to also generate thumbnail images, add the `--thumbnails` flag. You can specify the maximum pixel dimension of the generated thumbnail using `--thumbnail-size` with an integer value. The default is 640 pixels.
 
 ## Additional Options
 
-* Filenames, by default, will simply be formatted as `[level]_[time]Z.png`. If you would like more descriptive filenames, use the `--long_filenames` flag. This will utilize the full datestring in the output filenames.
+* Filenames, by default, will simply be formatted as `[level]_[time]Z.png`. If you would like more descriptive filenames, use the `--long-filenames` flag. This will utilize the full datestring in the output filenames.
 * The flag `--cwd` will tell the application to use the current working directory rather than a hard-coded path.

--- a/README.md
+++ b/README.md
@@ -56,6 +56,11 @@ This will plot dewpoint on the station plot for 850 and 925 (700 mb will always 
 
 By default, this script will output upper air maps as PNG files. Using the option `--compress_output` will enable more aggressive PNG optimization, including compression and indexing, reducing the file size by approximately 60%. This comes at the cost of an increased run time.
 
+The flag `--png_colours` can be used to specify the number of colours used in the output image. For example, `--png_colours 32` to restrict the output file to 32 colours. The default is 256 colours.
+
+If you want the script to also generate thumbnail images, add the `--thumbnails` flag. You can specify the maximum pixel dimension of the generated thumbnail using `--thumbnail_size` with an integer value. The default is 640 pixels.
+
 ## Additional Options
 
+* Filenames, by default, will simply be formatted as `[level]_[time]Z.png`. If you would like more descriptive filenames, use the `--long_filenames` flag. This will utilize the full datestring in the output filenames.
 * The flag `--cwd` will tell the application to use the current working directory rather than a hard-coded path.

--- a/uaplot.py
+++ b/uaplot.py
@@ -39,7 +39,17 @@ def main():
     parser.add_option("--te", "--te",dest='te', action="store_true", help="Plot Theta-e instead of temperatures for 925/850/700 mb", default=False)
     parser.add_option("--levels", "--levels",dest='levels',type="str", help="Levels in which to plot. Use levels=850,500 to plot specific levels. This option is not required to plot all levels (250, 300, 500, 700, 850, 925).", default='All')
     parser.add_option("--compress_output", "--compress_output", dest="compress",action="store_true", help="Compress the output PNGs when saving; will add extra to the runtime.", default=False)
-    parser.add_option("--cwd", "--cwd", dest="cwd",action="store_true", help="Use the current working directory rather than a hard-coded path.", default=False)
+    parser.add_option("--cwd", "--cwd", dest="cwd", action="store_true",
+                      help="Flag to use the current working directory instead of ~/UAMaps/.", default=False)
+    parser.add_option("--png_colours", "--png_colours", dest="png_colours",
+                      type="int", help="Number of colours to use in PNG comprssion.", default=256)
+    parser.add_option("--thumbnails", "--thumbnails", dest="thumbnails",
+                      action="store_true", help="Enable to generate thumbnail output as well.", default=False)
+    parser.add_option("--thumbnail_size", "--thumbnail_size", dest="thumbnail_size",
+                      type="int", help="Specify the maximum pixel dimension of a generated thumbnail.", default=640)
+    parser.add_option("--long_filenames", "--long_filenames", dest="long_filenames",
+                      action="store_true", help="Enable to create files with the full datestring in the output filenames.", default=False)
+					  
     (opt, arg) = parser.parse_args()
 
     if  opt.latest == False and opt.date == False:
@@ -411,46 +421,59 @@ def uaPlot(data, level, date, save_dir, ds, hour, td_option, te_option, date_opt
                 c.set_dashes([(0, (5.0, 3.0))])   
   
         else:
-            cs2 = ax.contour(lons, lats, smooth_tmpc.m, range(4, 56, tint), colors='red', transform=ccrs.PlateCarree())
-            cs3 = ax.contour(lons, lats, smooth_tmpc.m, range(-50, -4, tint), colors='blue', transform=ccrs.PlateCarree())
-            zeroline = ax.contour(lons, lats, smooth_tmpc.m, 0, colors='red', linestyles='solid', linewidths=3, transform=ccrs.PlateCarree())
+            cs2 = ax.contour(lons, lats, smooth_tmpc.m, range(
+                4, 56, tint), colors='red', transform=ccrs.PlateCarree())
+            cs3 = ax.contour(lons, lats, smooth_tmpc.m, range(-50, -4,
+                                                              tint), colors='blue', transform=ccrs.PlateCarree())
+            zeroline = ax.contour(lons, lats, smooth_tmpc.m, 0, colors='red',
+                                  linestyles='solid', linewidths=3, transform=ccrs.PlateCarree())
             if level == 700:
-                dingle_line = ax.contour(lons, lats, smooth_tmpc.m, [10], colors='brown', linestyles='solid', linewidths=3, transform=ccrs.PlateCarree())
-                dingle_line_label = plt.clabel(dingle_line, fmt='%d', colors='black', inline_spacing=5, use_clabeltext=True, fontsize=30)
-            zeroline_label = plt.clabel(zeroline, fmt='%d', colors='black', inline_spacing=5, use_clabeltext=True, fontsize=30)
-            clabels2 = plt.clabel(cs2, fmt='%d', colors='black', inline_spacing=5, use_clabeltext=True, fontsize=30)
-            clabels3 = plt.clabel(cs3, fmt='%d', colors='black', inline_spacing=5, use_clabeltext=True, fontsize=30)
+                dingle_line = ax.contour(lons, lats, smooth_tmpc.m, [
+                                         10], colors='brown', linestyles='solid', linewidths=3, transform=ccrs.PlateCarree())
+                dingle_line_label = plt.clabel(
+                    dingle_line, fmt='%d', colors='black', inline_spacing=5, use_clabeltext=True, fontsize=30)
+            zeroline_label = plt.clabel(
+                zeroline, fmt='%d', colors='black', inline_spacing=5, use_clabeltext=True, fontsize=30)
+            clabels2 = plt.clabel(cs2, fmt='%d', colors='black',
+                                  inline_spacing=5, use_clabeltext=True, fontsize=30)
+            clabels3 = plt.clabel(cs3, fmt='%d', colors='black',
+                                  inline_spacing=5, use_clabeltext=True, fontsize=30)
             temps = temps + ', and Temperature'
         # Set longer dashes than default
             for c in cs2.collections:
-                    c.set_dashes([(0, (5.0, 3.0))])    
+                c.set_dashes([(0, (5.0, 3.0))])
             for c in cs3.collections:
-                    c.set_dashes([(0, (5.0, 3.0))])    
-            
-        
-    
-    dpi = plt.rcParams['savefig.dpi'] = 255    
-    text = AnchoredText(str(level) + 'mb Wind, Heights, '+ temps +' Valid: {0:%Y-%m-%d} {0:%H}:00 UTC'.format(date), loc=3, frameon=True, prop=dict(fontsize=30))
+                c.set_dashes([(0, (5.0, 3.0))])
+
+    dpi = plt.rcParams['savefig.dpi'] = 255
+    text = AnchoredText(str(level) + 'mb Wind, Heights, ' + temps +
+                        ' Valid: {0:%Y-%m-%d} {0:%H}:00 UTC'.format(date), loc=3, frameon=True, prop=dict(fontsize=30))
     ax.add_artist(text)
     plt.tight_layout()
     if date_option != False:
-        save_fname = str(level) +'mb_{0:%Y%m%d%H%M}z.png'.format(date)
+        save_fname = str(level) + 'mb_{0:%Y%m%d%H%M}z.png'.format(date)
     else:
         if hour == 12:
-            save_fname = str(level) +'mb_'+ str(hour) +'z.png'
+            save_fname = str(level) + 'mb_' + str(hour) + 'z.png'
+            thumb_fname = str(level) + 'mb_' + str(hour) + 'z_thumbnail.png'
         if hour == 0:
-            save_fname = str(level) +'mb_'+ str(hour) +'0z.png'
+            save_fname = str(level) + 'mb_' + str(hour) + '0z.png'
+            thumb_fname = str(level) + 'mb_' + str(hour) + '0z_thumbnail.png'
     if image_compress is False:
-        plt.savefig(save_dir + "/" + save_fname, dpi = dpi, bbox_inches='tight')
+        plt.savefig(save_dir + "/" + save_fname, dpi=dpi, bbox_inches='tight')
     else:
         temp_img = BytesIO()
-        plt.savefig(temp_img, dpi = dpi, bbox_inches='tight')
+        plt.savefig(temp_img, dpi=dpi, bbox_inches='tight')
         temp_img.seek(0)
         im = Image.open(temp_img)
-        im2 = im.convert('RGB').convert('P', palette=Image.ADAPTIVE, colors=256)
+        im2 = im.convert('RGB').convert(
+            'P', palette=Image.ADAPTIVE, colors=png_colours)
         im2.save(save_dir + "/" + save_fname, format='PNG', optimize=True)
+        if (thumbnails != False):
+            im2.thumbnail((thumbnail_size, thumbnail_size), Image.ANTIALIAS)
+            im2.save(save_dir + "/" + thumb_fname, format='PNG', optimize=True)
     print('        Image saved.')
-    #plt.show()
+    # plt.show()
 
 if __name__ == '__main__':
     main()

--- a/uaplot.py
+++ b/uaplot.py
@@ -38,18 +38,18 @@ def main():
     parser.add_option("--td", "--td", dest='td', action="store_true", help="Plot dewpoint instead of dewpoint depression", default=False)
     parser.add_option("--te", "--te",dest='te', action="store_true", help="Plot Theta-e instead of temperatures for 925/850/700 mb", default=False)
     parser.add_option("--levels", "--levels",dest='levels',type="str", help="Levels in which to plot. Use levels=850,500 to plot specific levels. This option is not required to plot all levels (250, 300, 500, 700, 850, 925).", default='All')
-    parser.add_option("--compress_output", "--compress_output", dest="compress",action="store_true", help="Compress the output PNGs when saving; will add extra to the runtime.", default=False)
+    parser.add_option("--compress-output", "--compress-output", dest="compress",action="store_true", help="Compress the output PNGs when saving; will add extra to the runtime.", default=False)
     parser.add_option("--cwd", "--cwd", dest="cwd", action="store_true",
                       help="Flag to use the current working directory instead of ~/UAMaps/.", default=False)
-    parser.add_option("--png_colours", "--png_colours", dest="png_colours",
+    parser.add_option("--png-colours", "--png-colours", dest="png_colours",
                       type="int", help="Number of colours to use in PNG comprssion.", default=256)
     parser.add_option("--thumbnails", "--thumbnails", dest="thumbnails",
                       action="store_true", help="Enable to generate thumbnail output as well.", default=False)
-    parser.add_option("--thumbnail_size", "--thumbnail_size", dest="thumbnail_size",
+    parser.add_option("--thumbnail-size", "--thumbnail-size", dest="thumbnail_size",
                       type="int", help="Specify the maximum pixel dimension of a generated thumbnail.", default=640)
-    parser.add_option("--long_filenames", "--long_filenames", dest="long_filenames",
+    parser.add_option("--long-filenames", "--long-filenames", dest="long_filenames",
                       action="store_true", help="Enable to create files with the full datestring in the output filenames.", default=False)
-					  
+
     (opt, arg) = parser.parse_args()
 
     if  opt.latest == False and opt.date == False:

--- a/uaplot.py
+++ b/uaplot.py
@@ -74,13 +74,13 @@ def main():
 
     
     start = time.time()
-	if (opt.cwd):
-		path_root = getcwd()
-	else:
-		path_root = Path.home().as_posix()
-	
-    station_file = path_root + '/UAMaps/ua_station_list.csv'
-    save_dir = path_root + '/UAMaps/maps/' #Change the string to choose where to save the file. 
+    if (opt.cwd):
+        path_root = getcwd()
+    else:
+        path_root = Path.home().as_posix() + "/UAMaps/"
+
+    station_file = path_root + '/ua_station_list.csv'
+    save_dir = path_root + '/maps/' #Change the string to choose where to save the file. 
     dt = datetime.strptime(input_date.strftime('%Y%m%d') + str(hour), '%Y%m%d%H')
     date = dt - timedelta(hours=6) #Go back 6 hours to for 18z Objective Analysis.
     ds = xr.open_dataset('https://thredds.ucar.edu/thredds/dodsC/grib/NCEP/GFS/Global_0p5deg_ana/GFS_Global_0p5deg_ana_{0:%Y%m%d}_{0:%H}00.grib2'.format(date)).metpy.parse_cf()

--- a/uaplot.py
+++ b/uaplot.py
@@ -91,7 +91,7 @@ def main():
     for level in levels:
         print ("    Processing {}...".format(level))
         data = generateData(uadata, stations, level)
-        uaPlot(data, level, dt, save_dir, ds, hour, td_option, te_option, opt.date, opt.compress)
+        uaPlot(data, level, dt, save_dir, ds, hour, td_option, te_option, opt.date, opt.compress, opt.png_colours, opt.thumbnails, opt.thumbnail_size, opt.long_filenames)
     end = time.time()
     total_time = round(end-start, 2)
     print('Process Complete..... Total time = {}s'.format(total_time))
@@ -248,7 +248,7 @@ def mapbackground():
     return ax
 
 
-def uaPlot(data, level, date, save_dir, ds, hour, td_option, te_option, date_option, image_compress):
+def uaPlot(data, level, date, save_dir, ds, hour, td_option, te_option, date_option, image_compress, png_colours, thumbnails, thumbnail_size, long_filenames):
 
     custom_layout = StationPlotLayout()
     custom_layout.add_barb('eastward_wind', 'northward_wind', units='knots')

--- a/uaplot.py
+++ b/uaplot.py
@@ -450,8 +450,9 @@ def uaPlot(data, level, date, save_dir, ds, hour, td_option, te_option, date_opt
                         ' Valid: {0:%Y-%m-%d} {0:%H}:00 UTC'.format(date), loc=3, frameon=True, prop=dict(fontsize=30))
     ax.add_artist(text)
     plt.tight_layout()
-    if date_option != False:
-        save_fname = str(level) + 'mb_{0:%Y%m%d%H%M}z.png'.format(date)
+    if long_filenames == True:
+        save_fname = '{0:%Y%m%d_%H}Z_'.format(date) + str(level)  + 'mb.png'.format(date)
+        thumb_fname = '{0:%Y%m%d_%H}Z_'.format(date) + str(level)  + 'mb_thumbnail.png'
     else:
         if hour == 12:
             save_fname = str(level) + 'mb_' + str(hour) + 'z.png'
@@ -476,4 +477,4 @@ def uaPlot(data, level, date, save_dir, ds, hour, td_option, te_option, date_opt
     # plt.show()
 
 if __name__ == '__main__':
-    main()
+main()

--- a/uaplot.py
+++ b/uaplot.py
@@ -39,6 +39,7 @@ def main():
     parser.add_option("--te", "--te",dest='te', action="store_true", help="Plot Theta-e instead of temperatures for 925/850/700 mb", default=False)
     parser.add_option("--levels", "--levels",dest='levels',type="str", help="Levels in which to plot. Use levels=850,500 to plot specific levels. This option is not required to plot all levels (250, 300, 500, 700, 850, 925).", default='All')
     parser.add_option("--compress_output", "--compress_output", dest="compress",action="store_true", help="Compress the output PNGs when saving; will add extra to the runtime.", default=False)
+    parser.add_option("--cwd", "--cwd", dest="cwd",action="store_true", help="Use the current working directory rather than a hard-coded path.", default=False)
     (opt, arg) = parser.parse_args()
 
     if  opt.latest == False and opt.date == False:
@@ -63,10 +64,13 @@ def main():
 
     
     start = time.time()
-    home = Path.home().as_posix()
-    cwd = getcwd()
-    station_file = home + '/UAMaps/ua_station_list.csv'
-    save_dir = home + '/UAMaps/maps/' #Change the string to choose where to save the file. 
+	if (opt.cwd):
+		path_root = getcwd()
+	else:
+		path_root = Path.home().as_posix()
+	
+    station_file = path_root + '/UAMaps/ua_station_list.csv'
+    save_dir = path_root + '/UAMaps/maps/' #Change the string to choose where to save the file. 
     dt = datetime.strptime(input_date.strftime('%Y%m%d') + str(hour), '%Y%m%d%H')
     date = dt - timedelta(hours=6) #Go back 6 hours to for 18z Objective Analysis.
     ds = xr.open_dataset('https://thredds.ucar.edu/thredds/dodsC/grib/NCEP/GFS/Global_0p5deg_ana/GFS_Global_0p5deg_ana_{0:%Y%m%d}_{0:%H}00.grib2'.format(date)).metpy.parse_cf()


### PR DESCRIPTION
Implemented the following new arguments and options:

* `--cwd` to use the current working directory rather than a hard-coded path; `default=False`
* `--png-colours` to supply an integer to limit the number of colours that can be stored in the png file; `default=256`
* `--thumbnails` to produce thumbnail images in addition to the main images; `default=False`
* `--thumbnail-size` with an integer to specify the maximum pixel dimension of a thumbnail image; `default=640`
* `--long-filenames` to enable the use of date-stamped filenames in the output; `default=False`

The Readme has been updated with the new options, and all option flags have migrated from underscores to hyphens.

Tested for several days on my Mac at home with no issues. Personal test command was:

`python uaplot.py --latest --td --te --compress-output --cwd --thumbnails --long-filenames`